### PR TITLE
Presentation index - separating presentations by presenting/attending

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -48,7 +48,6 @@ class SurveysController < ApplicationController
 
     @survey.destroy
     redirect_to presentation_surveys_path
-
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+
+  def display_date(date)
+    date.strftime("%a - %-m/%d/%y @ %l:%M %P")
+  end
+
 end

--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -1,7 +1,7 @@
 module PresentationsHelper
 
-  def feedback_header(is_admin)
-    is_admin ? 'Admin' : 'Feedback'
+  def feedback_header
+    current_user.is_admin ? 'Admin' : 'Feedback'
   end
 
   def display_description(presentation)
@@ -21,8 +21,8 @@ module PresentationsHelper
     end
   end
 
-  def feedback_content(is_admin, presentation, feedback_message)
-    if is_admin
+  def feedback_content(presentation, feedback_message)
+    if current_user.is_admin
       edit_link = link_to "Edit", edit_presentation_path(presentation), class: 'btn btn-default'
       delete_link = link_to "Delete", presentation_path(presentation), class: "btn btn-default", method: :delete
       survey_link = survey_link_for(presentation)

--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -49,7 +49,7 @@ module PresentationsHelper
     end
   end
 
-  def feedback_content(user, presentation, feedback_message)
+  def feedback_content(user:, presentation:, feedback_message:)
     if user.is_admin
       edit_link = link_to "Edit", edit_presentation_path(presentation), class: 'btn btn-default'
       delete_link = link_to "Delete", presentation_path(presentation), class: "btn btn-default", method: :delete

--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -1,2 +1,21 @@
 module PresentationsHelper
+
+  def display_description(presentation)
+    if presentation.description.length > 30
+      content_tag(:span, presentation.description_short(30)) +
+      content_tag(:a, '(more)',
+        tabindex: '0',
+        role: 'button',
+        data: {
+          toggle: 'popover',
+          placement: 'bottom',
+          trigger: 'focus',
+          content: presentation.description
+        }
+      )
+    else
+      presentation.description
+    end
+  end
+
 end

--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -4,6 +4,10 @@ module PresentationsHelper
     current_user.is_admin ? 'Admin' : 'Feedback'
   end
 
+  def display_date(date)
+    date.strftime("%a - %-m/%d/%y @ %l:%M %P")
+  end
+
   def display_description(presentation)
     if presentation.description.length > 30
       description = content_tag(:span, presentation.description_short(30))

--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -10,12 +10,10 @@ module PresentationsHelper
       return Presentation.none
     end
 
-    presentation_ids = Participation.where(
-      user_id: current_user.id,
-      is_presenter: is_presenter
-    ).pluck(:presentation_id)
-
-    Presentation.find(presentation_ids)
+    Presentation.joins(:users, :participations).where(
+      users: { id: current_user.id },
+      participations: { is_presenter: is_presenter }
+    ).distinct
   end
 
   def admin_table

--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -26,7 +26,6 @@ module PresentationsHelper
 
   def general_user_table(role:, title:, feedback_message:)
     if !current_user.is_admin && presentations_as(role).any?
-      # render partial: 'presentations/table', locals: { title: title, presentations: current_user.presentations_as(role), feedback_message: feedback_message }
       render partial: 'presentations/table', locals: { title: title, presentations: presentations_as(role), feedback_message: feedback_message }
     end
   end

--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -1,20 +1,43 @@
 module PresentationsHelper
 
+  def feedback_header(is_admin)
+    is_admin ? 'Admin' : 'Feedback'
+  end
+
   def display_description(presentation)
     if presentation.description.length > 30
-      content_tag(:span, presentation.description_short(30)) + 
-      content_tag(:a, '(more)',
-        tabindex: '0',
-        role: 'button',
-        data: {
-          toggle: 'popover',
-          placement: 'bottom',
-          trigger: 'focus',
-          content: presentation.description
-        }
-      )
+      description = content_tag(:span, presentation.description_short(30))
+      view_link = content_tag(:a, '(more)', tabindex: '0', role: 'button',
+                    data: {
+                      toggle: 'popover',
+                      placement: 'bottom',
+                      trigger: 'focus',
+                      content: presentation.description
+                    }
+                  )
+      description + view_link
     else
       presentation.description
+    end
+  end
+
+  def feedback_content(is_admin, presentation, feedback_message)
+    if is_admin
+      edit_link = link_to "Edit", edit_presentation_path(presentation), class: 'btn btn-default'
+      delete_link = link_to "Delete", presentation_path(presentation), class: "btn btn-default", method: :delete
+      survey_link = survey_link_for(presentation)
+
+      edit_link + delete_link + survey_link
+    else
+      link_to feedback_message
+    end
+  end
+
+  def survey_link_for(presentation)
+    if presentation.surveys.any?
+      link_to "See Surveys", presentation_surveys_path(presentation)
+    else
+      link_to "Create Survey", new_presentation_survey_path(presentation)
     end
   end
 

--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -2,7 +2,7 @@ module PresentationsHelper
 
   def display_description(presentation)
     if presentation.description.length > 30
-      content_tag(:span, presentation.description_short(30)) +
+      content_tag(:span, presentation.description_short(30)) + 
       content_tag(:a, '(more)',
         tabindex: '0',
         role: 'button',

--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -16,20 +16,20 @@ module PresentationsHelper
     ).distinct
   end
 
-  def admin_table
-    if current_user.is_admin
+  def admin_table(user)
+    if user.is_admin
       render partial: 'presentations/table', locals: { title: "As Admin", presentations: @presentations, feedback_message: nil }
     end
   end
 
-  def general_user_table(role:, title:, feedback_message:)
-    if !current_user.is_admin && presentations_as(role, current_user).any?
-      render partial: 'presentations/table', locals: { title: title, presentations: presentations_as(role, current_user), feedback_message: feedback_message }
+  def general_user_table(user:, role:, title:, feedback_message:)
+    if !user.is_admin && presentations_as(role, user).any?
+      render partial: 'presentations/table', locals: { title: title, presentations: presentations_as(role, user), feedback_message: feedback_message }
     end
   end
 
-  def feedback_header
-    current_user.is_admin ? 'Admin' : 'Feedback'
+  def feedback_header(user)
+    user.is_admin ? 'Admin' : 'Feedback'
   end
 
   def display_description(presentation)
@@ -49,8 +49,8 @@ module PresentationsHelper
     end
   end
 
-  def feedback_content(presentation, feedback_message)
-    if current_user.is_admin
+  def feedback_content(user, presentation, feedback_message)
+    if user.is_admin
       edit_link = link_to "Edit", edit_presentation_path(presentation), class: 'btn btn-default'
       delete_link = link_to "Delete", presentation_path(presentation), class: "btn btn-default", method: :delete
       survey_link = survey_link_for(presentation)

--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -1,6 +1,6 @@
 module PresentationsHelper
 
-  def presentations_as(role)
+  def presentations_as(role, user)
     case role
     when :presenter
       is_presenter = true
@@ -11,7 +11,7 @@ module PresentationsHelper
     end
 
     Presentation.joins(:users, :participations).where(
-      users: { id: current_user.id },
+      users: { id: user.id },
       participations: { is_presenter: is_presenter }
     ).distinct
   end
@@ -23,8 +23,8 @@ module PresentationsHelper
   end
 
   def general_user_table(role:, title:, feedback_message:)
-    if !current_user.is_admin && presentations_as(role).any?
-      render partial: 'presentations/table', locals: { title: title, presentations: presentations_as(role), feedback_message: feedback_message }
+    if !current_user.is_admin && presentations_as(role, current_user).any?
+      render partial: 'presentations/table', locals: { title: title, presentations: presentations_as(role, current_user), feedback_message: feedback_message }
     end
   end
 

--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -1,11 +1,19 @@
 module PresentationsHelper
 
-  def feedback_header
-    current_user.is_admin ? 'Admin' : 'Feedback'
+  def admin_table
+    if current_user.is_admin
+      render partial: 'presentations/table', locals: { title: "As Admin", presentations: @presentations, feedback_message: nil }
+    end
   end
 
-  def display_date(date)
-    date.strftime("%a - %-m/%d/%y @ %l:%M %P")
+  def general_user_table(role:, title:, feedback_message:)
+    if !current_user.is_admin && current_user.presentations_as(role).any?
+      render partial: 'presentations/table', locals: { title: title, presentations: current_user.presentations_as(role), feedback_message: feedback_message }
+    end
+  end
+
+  def feedback_header
+    current_user.is_admin ? 'Admin' : 'Feedback'
   end
 
   def display_description(presentation)

--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -7,4 +7,8 @@ class Presentation < ApplicationRecord
   validates :title, presence: true
   validates :date, presence: true
   validates :location, presence: true
+
+  def description_short(length)
+    description[0..length].gsub(/\s\w+\s*$/, '...')
+  end
 end

--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -9,6 +9,8 @@ class Presentation < ApplicationRecord
   validates :location, presence: true
 
   def description_short(length)
+    raise ArgumentError if length < 1
+
     description[0..length].gsub(/\s\w+\s*$/, '...')
   end
 end

--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -9,8 +9,10 @@ class Presentation < ApplicationRecord
   validates :location, presence: true
 
   def description_short(length)
-    raise ArgumentError if length < 1
-
-    description[0..length].gsub(/\s\w+\s*$/, '...')
+    if length < 1
+      raise ArgumentError
+    else
+      description[0..length].gsub(/\s\w+\s*$/, '...')
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,9 +14,10 @@ class User < ApplicationRecord
   validates :last_name, presence: true
 
   def presentations_as(role)
-    if role == :presenter
+    case role
+    when :presenter
       presentations.where('is_presenter IS true')
-    elsif role == :attendee
+    when :attendee
       presentations.where('is_presenter IS NOT true')
     else
       User.none # empty ActiveRecord relation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ApplicationRecord
     when :attendee
       presentations.where('is_presenter IS NOT true')
     else
-      User.none # empty ActiveRecord relation
+      Presentation.none # empty ActiveRecord relation
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,14 +13,14 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
 
-  def presentations_as(role)
-    case role
-    when :presenter
-      presentations.where('is_presenter IS true')
-    when :attendee
-      presentations.where('is_presenter IS NOT true')
-    else
-      Presentation.none # empty ActiveRecord relation
-    end
-  end
+  # def presentations_as(role)
+  #   case role
+  #   when :presenter
+  #     presentations.where('is_presenter IS true')
+  #   when :attendee
+  #     presentations.where('is_presenter IS NOT true')
+  #   else
+  #     Presentation.none # empty ActiveRecord relation
+  #   end
+  # end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,15 +12,4 @@ class User < ApplicationRecord
 
   validates :first_name, presence: true
   validates :last_name, presence: true
-
-  # def presentations_as(role)
-  #   case role
-  #   when :presenter
-  #     presentations.where('is_presenter IS true')
-  #   when :attendee
-  #     presentations.where('is_presenter IS NOT true')
-  #   else
-  #     Presentation.none # empty ActiveRecord relation
-  #   end
-  # end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,11 +13,13 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
 
-  def presentations_as_presenter
-    presentations.where('is_presenter IS true')
-  end
-
-  def presentations_as_attendee
-    presentations.where('is_presenter IS NOT true')
+  def presentations_as(role)
+    if role == :presenter
+      presentations.where('is_presenter IS true')
+    elsif role == :attendee
+      presentations.where('is_presenter IS NOT true')
+    else
+      User.none # empty ActiveRecord relation
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,8 @@ class User < ApplicationRecord
 
   validates :first_name, presence: true
   validates :last_name, presence: true
+
+  def presentations_as_presenter
+    presentations.where('is_presenter IS true')
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,8 @@ class User < ApplicationRecord
   def presentations_as_presenter
     presentations.where('is_presenter IS true')
   end
+
+  def presentations_as_attendee
+    presentations.where('is_presenter IS NOT true')
+  end
 end

--- a/app/views/presentations/_table.html.erb
+++ b/app/views/presentations/_table.html.erb
@@ -1,0 +1,42 @@
+<table class="table table-striped">
+  <tr>
+    <th>Title</th>
+    <th>Date</th>
+    <th>Location</th>
+    <th>Description</th>
+    <% if current_user.is_admin %>
+      <th>Admin</th>
+    <% else %>
+      <th>Feedback</th>
+    <% end %>
+  </tr>
+<% presentations.each do |pre| %>
+  <tr>
+    <td><%= link_to pre.title, pre %></td>
+    <td><%= pre.date.strftime("%a - %-m/%d/%y @ %l:%M %P") %></td>
+    <td><%= pre.location %></td>
+    <td>
+      <% if pre.description.length > 30 %>
+        <%= pre.description[0..30].gsub(/\s\w+\s*$/, '... ') %><a tabindex="0" role="button" data-toggle="popover" data-placement="bottom" data-trigger="focus" data-content="<%= pre.description %>">(more)</a>
+      <% else %>
+        <%= pre.description %>
+      <% end %>
+    </td>
+    <% if current_user.is_admin %>
+      <td class="admin-link">
+        <%= link_to "Edit", edit_presentation_path(pre), class: "btn btn-default" %>
+        <%= link_to "Delete", presentation_path(pre), class: "btn btn-default", method: :delete %>
+        <% if pre.surveys.length == 0%>
+          <%= link_to "Create Survey", new_presentation_survey_path(pre) %>
+        <% else %>
+          <%= link_to "See Surveys", presentation_surveys_path(pre) %>
+        <% end %>
+      </td>
+    <% else %>
+    <td class="user-link">
+      <%= link_to feedback_message %>
+    </td>
+    <% end %>
+  </tr>
+<% end %>
+</table>

--- a/app/views/presentations/_table.html.erb
+++ b/app/views/presentations/_table.html.erb
@@ -1,3 +1,4 @@
+<h2><%= title %></h2>
 <table class="table table-striped">
   <tr>
     <th>Title</th>

--- a/app/views/presentations/_table.html.erb
+++ b/app/views/presentations/_table.html.erb
@@ -4,7 +4,7 @@
     <th>Date</th>
     <th>Location</th>
     <th>Description</th>
-    <th><%= feedback_header(current_user.is_admin) %></th>
+    <th><%= feedback_header %></th>
   </tr>
   <% presentations.each do |pre| %>
   <tr>
@@ -12,7 +12,7 @@
     <td><%= pre.date.strftime("%a - %-m/%d/%y @ %l:%M %P") %></td>
     <td><%= pre.location %></td>
     <td><%= display_description(pre) %></td>
-    <td><%= feedback_content(current_user.is_admin, pre, feedback_message) %></td>
+    <td><%= feedback_content(pre, feedback_message) %></td>
   </tr>
   <% end %>
 </table>

--- a/app/views/presentations/_table.html.erb
+++ b/app/views/presentations/_table.html.erb
@@ -5,7 +5,7 @@
     <th>Date</th>
     <th>Location</th>
     <th>Description</th>
-    <th><%= feedback_header %></th>
+    <th><%= feedback_header(current_user) %></th>
   </tr>
   <% presentations.each do |pre| %>
   <tr>
@@ -13,7 +13,7 @@
     <td><%= display_date(pre.date) %></td>
     <td><%= pre.location %></td>
     <td><%= display_description(pre) %></td>
-    <td><%= feedback_content(pre, feedback_message) %></td>
+    <td><%= feedback_content(current_user, pre, feedback_message) %></td>
   </tr>
   <% end %>
 </table>

--- a/app/views/presentations/_table.html.erb
+++ b/app/views/presentations/_table.html.erb
@@ -9,7 +9,7 @@
   <% presentations.each do |pre| %>
   <tr>
     <td><%= link_to pre.title, pre %></td>
-    <td><%= pre.date.strftime("%a - %-m/%d/%y @ %l:%M %P") %></td>
+    <td><%= display_date(pre.date) %></td>
     <td><%= pre.location %></td>
     <td><%= display_description(pre) %></td>
     <td><%= feedback_content(pre, feedback_message) %></td>

--- a/app/views/presentations/_table.html.erb
+++ b/app/views/presentations/_table.html.erb
@@ -13,7 +13,11 @@
     <td><%= display_date(pre.date) %></td>
     <td><%= pre.location %></td>
     <td><%= display_description(pre) %></td>
-    <td><%= feedback_content(current_user, pre, feedback_message) %></td>
+    <td><%= feedback_content(
+          user: current_user,
+          presentation: pre,
+          feedback_message: feedback_message
+        ) %></td>
   </tr>
   <% end %>
 </table>

--- a/app/views/presentations/_table.html.erb
+++ b/app/views/presentations/_table.html.erb
@@ -15,13 +15,7 @@
     <td><%= link_to pre.title, pre %></td>
     <td><%= pre.date.strftime("%a - %-m/%d/%y @ %l:%M %P") %></td>
     <td><%= pre.location %></td>
-    <td>
-      <% if pre.description.length > 30 %>
-        <%= pre.description[0..30].gsub(/\s\w+\s*$/, '... ') %><a tabindex="0" role="button" data-toggle="popover" data-placement="bottom" data-trigger="focus" data-content="<%= pre.description %>">(more)</a>
-      <% else %>
-        <%= pre.description %>
-      <% end %>
-    </td>
+    <td><%= display_description(pre) %></td>
     <% if current_user.is_admin %>
       <td class="admin-link">
         <%= link_to "Edit", edit_presentation_path(pre), class: "btn btn-default" %>

--- a/app/views/presentations/_table.html.erb
+++ b/app/views/presentations/_table.html.erb
@@ -4,33 +4,15 @@
     <th>Date</th>
     <th>Location</th>
     <th>Description</th>
-    <% if current_user.is_admin %>
-      <th>Admin</th>
-    <% else %>
-      <th>Feedback</th>
-    <% end %>
+    <th><%= feedback_header(current_user.is_admin) %></th>
   </tr>
-<% presentations.each do |pre| %>
+  <% presentations.each do |pre| %>
   <tr>
     <td><%= link_to pre.title, pre %></td>
     <td><%= pre.date.strftime("%a - %-m/%d/%y @ %l:%M %P") %></td>
     <td><%= pre.location %></td>
     <td><%= display_description(pre) %></td>
-    <% if current_user.is_admin %>
-      <td class="admin-link">
-        <%= link_to "Edit", edit_presentation_path(pre), class: "btn btn-default" %>
-        <%= link_to "Delete", presentation_path(pre), class: "btn btn-default", method: :delete %>
-        <% if pre.surveys.length == 0%>
-          <%= link_to "Create Survey", new_presentation_survey_path(pre) %>
-        <% else %>
-          <%= link_to "See Surveys", presentation_surveys_path(pre) %>
-        <% end %>
-      </td>
-    <% else %>
-    <td class="user-link">
-      <%= link_to feedback_message %>
-    </td>
-    <% end %>
+    <td><%= feedback_content(current_user.is_admin, pre, feedback_message) %></td>
   </tr>
-<% end %>
+  <% end %>
 </table>

--- a/app/views/presentations/index.html.erb
+++ b/app/views/presentations/index.html.erb
@@ -6,14 +6,14 @@
 
 <% else %>
 
-  <% if current_user.presentations_as_presenter.any? %>
+  <% if current_user.presentations_as(:presenter).any? %>
     <h2>As Presenter</h2>
-    <%= render partial: 'presentations/table', locals: { presentations: current_user.presentations_as_presenter, feedback_message: "See Feedback" } %>
+    <%= render partial: 'presentations/table', locals: { presentations: current_user.presentations_as(:presenter), feedback_message: "See Feedback" } %>
   <% end %>
 
-  <% if current_user.presentations_as_attendee.any? %>
+  <% if current_user.presentations_as(:attendee).any? %>
     <h2>As Attendee</h2>
-    <%= render partial: 'presentations/table', locals: { presentations: current_user.presentations_as_attendee, feedback_message: "Provide Feedback" } %>
+    <%= render partial: 'presentations/table', locals: { presentations: current_user.presentations_as(:attendee), feedback_message: "Provide Feedback" } %>
   <% end %>
 
 <% end %>

--- a/app/views/presentations/index.html.erb
+++ b/app/views/presentations/index.html.erb
@@ -1,89 +1,11 @@
 <h1>Presentations</h1>
 
+<% if current_user.presentations_as_presenter.any? %>
 <h2>As Presenter</h2>
-<table class="table table-striped">
-  <tr>
-    <th>Title</th>
-    <th>Date</th>
-    <th>Location</th>
-    <th>Description</th>
-    <% if current_user.is_admin %>
-      <th>Admin</th>
-    <% else %>
-      <th>Feedback</th>
-    <% end %>
-  </tr>
-<% current_user.presentations_as_presenter.each do |pre| %>
-  <tr>
-    <td><%= link_to pre.title, pre %></td>
-    <td><%= pre.date.strftime("%a - %-m/%d/%y @ %l:%M %P") %></td>
-    <td><%= pre.location %></td>
-    <td>
-      <% if pre.description.length > 30 %>
-        <%= pre.description[0..30].gsub(/\s\w+\s*$/, '... ') %><a tabindex="0" role="button" data-toggle="popover" data-placement="bottom" data-trigger="focus" data-content="<%= pre.description %>">(more)</a>
-      <% else %>
-        <%= pre.description %>
-      <% end %>
-    </td>
-    <% if current_user.is_admin %>
-      <td class="admin-link">
-        <%= link_to "Edit", edit_presentation_path(pre), class: "btn btn-default" %>
-        <%= link_to "Delete", presentation_path(pre), class: "btn btn-default", method: :delete %>
-        <% if pre.surveys.length == 0%>
-          <%= link_to "Create Survey", new_presentation_survey_path(pre) %>
-        <% else %>
-          <%= link_to "See Surveys", presentation_surveys_path(pre) %>
-        <% end %>
-      </td>
-    <% else %>
-    <td class="user-link">
-      <%= link_to "See Feedback" %>
-    </td>
-    <% end %>
-  </tr>
+<%= render partial: 'presentations/table', locals: { presentations: current_user.presentations_as_presenter, feedback_message: "See Feedback" } %>
 <% end %>
-</table>
 
+<% if current_user.presentations_as_attendee.any? %>
 <h2>As Attendee</h2>
-<table class="table table-striped">
-  <tr>
-    <th>Title</th>
-    <th>Date</th>
-    <th>Location</th>
-    <th>Description</th>
-    <% if current_user.is_admin %>
-      <th>Admin</th>
-    <% else %>
-      <th>Feedback</th>
-    <% end %>
-  </tr>
-<% current_user.presentations_as_attendee.each do |pre| %>
-  <tr>
-    <td><%= link_to pre.title, pre %></td>
-    <td><%= pre.date.strftime("%a - %-m/%d/%y @ %l:%M %P") %></td>
-    <td><%= pre.location %></td>
-    <td>
-      <% if pre.description.length > 30 %>
-        <%= pre.description[0..30].gsub(/\s\w+\s*$/, '... ') %><a tabindex="0" role="button" data-toggle="popover" data-placement="bottom" data-trigger="focus" data-content="<%= pre.description %>">(more)</a>
-      <% else %>
-        <%= pre.description %>
-      <% end %>
-    </td>
-    <% if current_user.is_admin %>
-      <td class="admin-link">
-        <%= link_to "Edit", edit_presentation_path(pre), class: "btn btn-default" %>
-        <%= link_to "Delete", presentation_path(pre), class: "btn btn-default", method: :delete %>
-        <% if pre.surveys.length == 0%>
-          <%= link_to "Create Survey", new_presentation_survey_path(pre) %>
-        <% else %>
-          <%= link_to "See Surveys", presentation_surveys_path(pre) %>
-        <% end %>
-      </td>
-    <% else %>
-    <td class="user-link">
-      <%= link_to "Provide Feedback" %>
-    </td>
-    <% end %>
-  </tr>
+<%= render partial: 'presentations/table', locals: { presentations: current_user.presentations_as_attendee, feedback_message: "Provide Feedback" } %>
 <% end %>
-</table>

--- a/app/views/presentations/index.html.erb
+++ b/app/views/presentations/index.html.erb
@@ -7,6 +7,8 @@
     <th>Description</th>
     <% if current_user.is_admin %>
       <th>Admin</th>
+    <% else %>
+      <th>Feedback</th>
     <% end %>
   </tr>
 <% @presentations.each do |pre| %>

--- a/app/views/presentations/index.html.erb
+++ b/app/views/presentations/index.html.erb
@@ -2,7 +2,7 @@
 
 <% if current_user.is_admin? %>
 
-  <%= render partial: 'presentations/table', locals: { presentations: @presentations } %>
+  <%= render partial: 'presentations/table', locals: { presentations: @presentations, feedback_message: nil } %>
 
 <% else %>
 

--- a/app/views/presentations/index.html.erb
+++ b/app/views/presentations/index.html.erb
@@ -1,11 +1,19 @@
 <h1>Presentations</h1>
 
-<% if current_user.presentations_as_presenter.any? %>
-<h2>As Presenter</h2>
-<%= render partial: 'presentations/table', locals: { presentations: current_user.presentations_as_presenter, feedback_message: "See Feedback" } %>
-<% end %>
+<% if current_user.is_admin? %>
 
-<% if current_user.presentations_as_attendee.any? %>
-<h2>As Attendee</h2>
-<%= render partial: 'presentations/table', locals: { presentations: current_user.presentations_as_attendee, feedback_message: "Provide Feedback" } %>
+  <%= render partial: 'presentations/table', locals: { presentations: @presentations } %>
+
+<% else %>
+
+  <% if current_user.presentations_as_presenter.any? %>
+    <h2>As Presenter</h2>
+    <%= render partial: 'presentations/table', locals: { presentations: current_user.presentations_as_presenter, feedback_message: "See Feedback" } %>
+  <% end %>
+
+  <% if current_user.presentations_as_attendee.any? %>
+    <h2>As Attendee</h2>
+    <%= render partial: 'presentations/table', locals: { presentations: current_user.presentations_as_attendee, feedback_message: "Provide Feedback" } %>
+  <% end %>
+
 <% end %>

--- a/app/views/presentations/index.html.erb
+++ b/app/views/presentations/index.html.erb
@@ -1,19 +1,7 @@
 <h1>Presentations</h1>
 
-<% if current_user.is_admin? %>
+<%= admin_table %>
 
-  <%= render partial: 'presentations/table', locals: { presentations: @presentations, feedback_message: nil } %>
+<%= general_user_table(role: :presenter, title: "As Presenter", feedback_message: "See Feedback") %>
 
-<% else %>
-
-  <% if current_user.presentations_as(:presenter).any? %>
-    <h2>As Presenter</h2>
-    <%= render partial: 'presentations/table', locals: { presentations: current_user.presentations_as(:presenter), feedback_message: "See Feedback" } %>
-  <% end %>
-
-  <% if current_user.presentations_as(:attendee).any? %>
-    <h2>As Attendee</h2>
-    <%= render partial: 'presentations/table', locals: { presentations: current_user.presentations_as(:attendee), feedback_message: "Provide Feedback" } %>
-  <% end %>
-
-<% end %>
+<%= general_user_table(role: :attendee, title: "As Attendee", feedback_message: "Provide Feedback") %>

--- a/app/views/presentations/index.html.erb
+++ b/app/views/presentations/index.html.erb
@@ -1,4 +1,6 @@
 <h1>Presentations</h1>
+
+<h2>As Presenter</h2>
 <table class="table table-striped">
   <tr>
     <th>Title</th>
@@ -11,7 +13,51 @@
       <th>Feedback</th>
     <% end %>
   </tr>
-<% @presentations.each do |pre| %>
+<% current_user.presentations_as_presenter.each do |pre| %>
+  <tr>
+    <td><%= link_to pre.title, pre %></td>
+    <td><%= pre.date.strftime("%a - %-m/%d/%y @ %l:%M %P") %></td>
+    <td><%= pre.location %></td>
+    <td>
+      <% if pre.description.length > 30 %>
+        <%= pre.description[0..30].gsub(/\s\w+\s*$/, '... ') %><a tabindex="0" role="button" data-toggle="popover" data-placement="bottom" data-trigger="focus" data-content="<%= pre.description %>">(more)</a>
+      <% else %>
+        <%= pre.description %>
+      <% end %>
+    </td>
+    <% if current_user.is_admin %>
+      <td class="admin-link">
+        <%= link_to "Edit", edit_presentation_path(pre), class: "btn btn-default" %>
+        <%= link_to "Delete", presentation_path(pre), class: "btn btn-default", method: :delete %>
+        <% if pre.surveys.length == 0%>
+          <%= link_to "Create Survey", new_presentation_survey_path(pre) %>
+        <% else %>
+          <%= link_to "See Surveys", presentation_surveys_path(pre) %>
+        <% end %>
+      </td>
+    <% else %>
+    <td class="user-link">
+      <%= link_to "See Feedback" %>
+    </td>
+    <% end %>
+  </tr>
+<% end %>
+</table>
+
+<h2>As Attendee</h2>
+<table class="table table-striped">
+  <tr>
+    <th>Title</th>
+    <th>Date</th>
+    <th>Location</th>
+    <th>Description</th>
+    <% if current_user.is_admin %>
+      <th>Admin</th>
+    <% else %>
+      <th>Feedback</th>
+    <% end %>
+  </tr>
+<% current_user.presentations_as_attendee.each do |pre| %>
   <tr>
     <td><%= link_to pre.title, pre %></td>
     <td><%= pre.date.strftime("%a - %-m/%d/%y @ %l:%M %P") %></td>

--- a/app/views/presentations/index.html.erb
+++ b/app/views/presentations/index.html.erb
@@ -1,7 +1,17 @@
 <h1>Presentations</h1>
 
-<%= admin_table %>
+<%= admin_table(current_user) %>
 
-<%= general_user_table(role: :presenter, title: "As Presenter", feedback_message: "See Feedback") %>
+<%= general_user_table(
+  user: current_user,
+  role: :presenter,
+  title: "As Presenter",
+  feedback_message: "See Feedback"
+) %>
 
-<%= general_user_table(role: :attendee, title: "As Attendee", feedback_message: "Provide Feedback") %>
+<%= general_user_table(
+  user: current_user,
+  role: :attendee,
+  title: "As Attendee",
+  feedback_message: "Provide Feedback"
+) %>

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -14,8 +14,10 @@
     <tr>
       <td><%= link_to "#{survey.subject}", presentation_survey_path(@presentation.id, survey.id) %></td>
       <td><%= survey.order %></td>
-      <td><%= link_to "Edit", edit_presentation_survey_path(@presentation.id, survey.id) %></td>
-      <td><%= link_to "Delete", presentation_survey_path(@presentation.id, survey.id), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      <td>
+        <%= link_to "Edit", edit_presentation_survey_path(@presentation.id, survey.id), class: "btn btn-default" %>
+        <%= link_to "Delete", presentation_survey_path(@presentation.id, survey.id), class: "btn btn-default", method: :delete, data: { confirm: 'Are you sure?' } %>
+      </td>
     </tr>
   <% end %>
 </table>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -92,7 +92,8 @@ Presentation.all.each do |pres|
     if part.nil?
       new_part = Participation.create(
         user_id: u.id,
-        presentation_id: pres.id
+        presentation_id: pres.id,
+        is_presenter: false
       )
       # Set first user as presenter
       if pres.users.count == 1

--- a/test/controllers/presentations_controller_test.rb
+++ b/test/controllers/presentations_controller_test.rb
@@ -21,17 +21,21 @@ class PresentationsControllerTest < ActionController::TestCase
       admin = create :user, :admin
       presentation = create :presentation
       sign_in admin
+
       get :index
+
       assert_equal Presentation.all, [presentation], "Did not return presentations"
     end
 
     it "gets only presentations for which a non-admin user is a participant" do
-      u = create :user
+      user = create :user
       pres1 = create :presentation
       pres2 = create :presentation
-      part = create :participation, user: u, presentation: pres1
-      sign_in u
+      part = create :participation, user: user, presentation: pres1
+      sign_in user
+
       get :index
+
       assert_equal u.presentations, [pres1], "Returned presentation for which the user is not a participant"
     end
   end
@@ -42,12 +46,15 @@ class PresentationsControllerTest < ActionController::TestCase
     it "redirects to index page if logged in" do
       user = create :user
       sign_in user
+
       post :create, params: @params
+
       assert_redirected_to presentations_path, "Create method unsuccessful, no redirect to presentations_path"
     end
 
     it "redirects to sign-in page if a user is not signed in" do
       post :create, params: @params
+      
       assert_redirected_to new_user_session_path
     end
 

--- a/test/controllers/presentations_controller_test.rb
+++ b/test/controllers/presentations_controller_test.rb
@@ -36,7 +36,7 @@ class PresentationsControllerTest < ActionController::TestCase
 
       get :index
 
-      assert_equal u.presentations, [pres1], "Returned presentation for which the user is not a participant"
+      assert_equal user.presentations, [pres1], "Returned presentation for which the user is not a participant"
     end
   end
 
@@ -54,7 +54,7 @@ class PresentationsControllerTest < ActionController::TestCase
 
     it "redirects to sign-in page if a user is not signed in" do
       post :create, params: @params
-      
+
       assert_redirected_to new_user_session_path
     end
 

--- a/test/controllers/surveys_controller_test.rb
+++ b/test/controllers/surveys_controller_test.rb
@@ -12,7 +12,6 @@ class SurveysControllerTest < ActionController::TestCase
         sign_in admin
         post :create, params: {presentation_id: presentation.id, survey:{ order: 1, subject: "Git"}}
         assert_redirected_to presentation_survey_path(presentation.id, presentation.surveys.first.id), "Create method unsuccessful, no redirect to presentations_survey_path"
-
       end
     end
 

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -18,6 +18,10 @@ FactoryGirl.define do
     date DateTime.now
     location "location"
     description "description"
+
+    trait :long_description do
+      description "description description description description description description"
+    end
   end
 
   factory :participation do

--- a/test/features/authentication/sign_in_test.rb
+++ b/test/features/authentication/sign_in_test.rb
@@ -9,21 +9,25 @@ class SignInTest < Capybara::Rails::TestCase
 
     scenario "has valid content" do
       u = create :user
+
       within ("form") do
         fill_in "Email", with: u.email
         fill_in "Password", with: u.password
         click_button "Log In"
       end
+
       assert_equal current_path, root_path
     end
 
     scenario "has invalid password" do
       u = create :user
+
       within ("form") do
         fill_in "Email", with: u.email
         fill_in "Password", with: u.password + "_wrong"
         click_button "Log In"
       end
+      
       assert_equal current_path, new_user_session_path
     end
   end

--- a/test/features/authentication/sign_out_test.rb
+++ b/test/features/authentication/sign_out_test.rb
@@ -12,9 +12,11 @@ class SignOutTest < Capybara::Rails::TestCase
     scenario "visits sign out path" do
       user = create :user
       login_as(user, scope: :user)
+
       # Must refresh page for login_as to take effect
       visit root_path
       click_on "Log Out"
+      
       # Check for "Log In" option in nav
       page.must_have_content "Log In"
     end

--- a/test/features/authentication/sign_up_test.rb
+++ b/test/features/authentication/sign_up_test.rb
@@ -16,6 +16,7 @@ class SignUpTest < Capybara::Rails::TestCase
         fill_in "Password confirmation", with: "testing"
         click_button "Sign Up"
       end
+
       assert_equal current_path, root_path
     end
 
@@ -28,6 +29,7 @@ class SignUpTest < Capybara::Rails::TestCase
         fill_in "Password confirmation", with: "badpassword"
         click_button "Sign Up"
       end
+      
       page.must_have_content "Password confirmation doesn't match Password"
     end
   end

--- a/test/features/presentations/create_presentation_test.rb
+++ b/test/features/presentations/create_presentation_test.rb
@@ -12,9 +12,12 @@ class CreatePresentationTest < Capybara::Rails::TestCase
     scenario "creates a new presentation if admin" do
       u = create :user, :admin
       login_as(u, scope: :user)
+
       # Must refresh page for login_as to take effect
       visit root_path
+
       click_on "Create New Presentation"
+
       within ("form") do
         fill_in "Title", with: "Foo Bar"
         fill_in "Location", with: "Over there"
@@ -22,6 +25,7 @@ class CreatePresentationTest < Capybara::Rails::TestCase
         fill_in "Description", with: "Lorem ipsum"
         click_button "Submit"
       end
+
       # Check for "Foo Bar" listing
       page.must_have_content "Foo Bar"
     end
@@ -29,8 +33,10 @@ class CreatePresentationTest < Capybara::Rails::TestCase
     scenario "redirects to presentation index if non-admin" do
       u = create :user
       login_as(u, scope: :user)
+
       # Must refresh page for login_as to take effect
       visit new_presentation_path
+
       assert_equal current_path, presentations_path
     end
   end

--- a/test/features/presentations/presentations_list_test.rb
+++ b/test/features/presentations/presentations_list_test.rb
@@ -32,7 +32,6 @@ class PresentationsListTest < Capybara::Rails::TestCase
       pres = create(:presentation)
       create(:participation, user: @user, presentation: pres)
       visit(presentations_path)
-      save_and_open_page
       within('table') do
         refute page.has_content? "Admin"
       end

--- a/test/features/presentations/presentations_list_test.rb
+++ b/test/features/presentations/presentations_list_test.rb
@@ -28,6 +28,17 @@ class PresentationsListTest < Capybara::Rails::TestCase
       assert page.has_selector?('table tr', count: 2) # 1 presentation + 1 header row
     end
 
+    scenario "a general user sees separate tables for sessions where they are presenting and attending" do
+      pres_1 = create(:presentation, title: "user's presentation")
+      create(:participation, user: @user, presentation: pres_1, is_presenter: true)
+      pres_2 = create(:presentation, title: "another presentation")
+      create(:participation, user: @user, presentation: pres_2, is_presenter: false)
+      visit(presentations_path)
+      assert page.has_selector?('table', count: 2), "Two tables are not present on the page"
+      assert page.has_content?('As Presenter'), "Presenter header does not show up on page"
+      assert page.has_content?('As Attendee'), "Attendee header does not show up on page"
+    end
+
     scenario "a general user cannot see the admin column" do
       pres = create(:presentation)
       create(:participation, user: @user, presentation: pres)

--- a/test/features/presentations/presentations_list_test.rb
+++ b/test/features/presentations/presentations_list_test.rb
@@ -12,7 +12,9 @@ class PresentationsListTest < Capybara::Rails::TestCase
     before do
       @user = create(:user)
       login_as(@user, scope: :user)
+
       visit(root_path)
+
       within("nav") { click_on("View Presentations") }
     end
 
@@ -22,18 +24,24 @@ class PresentationsListTest < Capybara::Rails::TestCase
 
     scenario "a general user can only see their own presentations" do
       create_list(:presentation, 10)
+
       pres = create(:presentation, title: "user's presentation")
       create(:participation, user: @user, presentation: pres)
+
       visit(presentations_path)
+
       assert page.has_selector?('table tr', count: 2) # 1 presentation + 1 header row
     end
 
     scenario "a general user sees separate tables for sessions where they are presenting and attending" do
       pres_1 = create(:presentation, title: "user's presentation")
-      create(:participation, user: @user, presentation: pres_1, is_presenter: true)
       pres_2 = create(:presentation, title: "another presentation")
+
+      create(:participation, user: @user, presentation: pres_1, is_presenter: true)
       create(:participation, user: @user, presentation: pres_2, is_presenter: false)
+
       visit(presentations_path)
+
       assert page.has_selector?('table', count: 2), "Two tables are not present on the page"
       assert page.has_content?('As Presenter'), "Presenter header does not show up on page"
       assert page.has_content?('As Attendee'), "Attendee header does not show up on page"
@@ -42,7 +50,9 @@ class PresentationsListTest < Capybara::Rails::TestCase
     scenario "a general user cannot see the admin column" do
       pres = create(:presentation)
       create(:participation, user: @user, presentation: pres)
+
       visit(presentations_path)
+
       within('table') do
         refute page.has_content? "Admin"
       end
@@ -53,13 +63,17 @@ class PresentationsListTest < Capybara::Rails::TestCase
     before do
       admin = create(:user, :admin)
       login_as(admin, scope: :user)
+
       visit(root_path)
+
       within("nav") { click_on("View Presentations") }
     end
 
     scenario "an admin can see all of the presentations" do
       create_list(:presentation, 10)
+
       visit(presentations_path)
+
       assert page.has_selector?('table tr', count: 11) # 10 presentations + 1 header row
     end
 

--- a/test/features/presentations/presentations_list_test.rb
+++ b/test/features/presentations/presentations_list_test.rb
@@ -29,6 +29,10 @@ class PresentationsListTest < Capybara::Rails::TestCase
     end
 
     scenario "a general user cannot see the admin column" do
+      pres = create(:presentation)
+      create(:participation, user: @user, presentation: pres)
+      visit(presentations_path)
+      save_and_open_page
       within('table') do
         refute page.has_content? "Admin"
       end

--- a/test/helpers/presentations_helper_test.rb
+++ b/test/helpers/presentations_helper_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class PresentationsHelperTest < ActionView::TestCase
+  include Devise::Test::ControllerHelpers
+
   before do
     @user = create(:user)
 
@@ -22,11 +24,13 @@ class PresentationsHelperTest < ActionView::TestCase
   describe '#presentations_as' do
     it 'gets correct presentations when current user is presenter' do
       presentations = presentations_as(:presenter, @user)
+
       assert_equal presentations, [@presentation_as_presenter]
     end
 
     it 'gets correct presentations where current user is attendee' do
       presentations = presentations_as(:attendee, @user)
+
       assert_equal presentations, [@presentation_as_attendee]
     end
 

--- a/test/helpers/presentations_helper_test.rb
+++ b/test/helpers/presentations_helper_test.rb
@@ -1,12 +1,8 @@
 require 'test_helper'
 
 class PresentationsHelperTest < ActionView::TestCase
-  # include Warden::Test::Helpers
-  # Warden.test_mode!
-
   before do
     @user = create(:user)
-    # login_as(@user, scope: :user)
 
     @presentation_as_presenter = create(:presentation)
     @presentation_as_attendee = create(:presentation)
@@ -23,17 +19,27 @@ class PresentationsHelperTest < ActionView::TestCase
     )
   end
 
-  # after do
-  #   Warden.test_reset!
-  # end
-
   describe '#presentations_as' do
     it 'gets correct presentations when current user is presenter' do
-      assert_equal presentations_as(:presenter, @user), [@presentation_as_presenter]
+      presentations = presentations_as(:presenter, @user)
+      assert_equal presentations, [@presentation_as_presenter]
     end
 
-    it 'gets correct presentations where current user is attendee'
-    it 'returns an empty relation is role is not specified as presenter or attendee'
-    it 'raises an error if role is not specified'
+    it 'gets correct presentations where current user is attendee' do
+      presentations = presentations_as(:attendee, @user)
+      assert_equal presentations, [@presentation_as_attendee]
+    end
+
+    it 'returns an empty relation is role is not specified as presenter or attendee' do
+      assert_equal presentations_as(:another_role, @user), []
+    end
+
+    it 'raises an error if role is not specified' do
+      assert_raises(ArgumentError) { presentations_as(@user) }
+    end
+
+    it 'raises an error if user is not specified' do
+      assert_raises(ArgumentError) { presentations_as(:presenter) }
+    end
   end
 end

--- a/test/helpers/presentations_helper_test.rb
+++ b/test/helpers/presentations_helper_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class PresentationsHelperTest < ActionView::TestCase
+  # include Warden::Test::Helpers
+  # Warden.test_mode!
+
+  before do
+    @user = create(:user)
+    # login_as(@user, scope: :user)
+
+    @presentation_as_presenter = create(:presentation)
+    @presentation_as_attendee = create(:presentation)
+
+    create(:participation,
+      user_id: @user.id,
+      presentation_id: @presentation_as_presenter.id,
+      is_presenter: true
+    )
+    create(:participation,
+      user_id: @user.id,
+      presentation_id: @presentation_as_attendee.id,
+      is_presenter: false
+    )
+  end
+
+  # after do
+  #   Warden.test_reset!
+  # end
+
+  describe '#presentations_as' do
+    it 'gets correct presentations when current user is presenter' do
+      assert_equal presentations_as(:presenter, @user), [@presentation_as_presenter]
+    end
+
+    it 'gets correct presentations where current user is attendee'
+    it 'returns an empty relation is role is not specified as presenter or attendee'
+    it 'raises an error if role is not specified'
+  end
+end

--- a/test/models/presentation_test.rb
+++ b/test/models/presentation_test.rb
@@ -9,24 +9,28 @@ describe Presentation do
 
   it 'accepts a valid presentation' do
     result = @presentation.valid?
+
     assert result, "Valid presentation was considered invalid"
   end
 
   it 'rejects a presentation without a title' do
     @presentation.title = nil
     result = @presentation.valid?
+
     refute result, "Accepted presentation with invalid title"
   end
 
   it 'rejects a presentation without a date' do
     @presentation.date = nil
     result = @presentation.valid?
+
     refute result, "Accepted presentation with invalid date"
   end
 
   it 'rejects a presentation without a location' do
     @presentation.location = nil
     result = @presentation.valid?
+    
     refute result, "Accepted presentation with invalid location"
   end
 

--- a/test/models/presentation_test.rb
+++ b/test/models/presentation_test.rb
@@ -4,7 +4,7 @@ include FactoryGirl::Syntax::Methods
 describe Presentation do
 
   before do
-    @presentation = build(:presentation)
+    @presentation = create(:presentation)
   end
 
   it 'accepts a valid presentation' do
@@ -36,8 +36,20 @@ describe Presentation do
 
   describe '#description_short' do
 
+    before do
+      @presentation = create(:presentation, :long_description)
+    end
+
     it 'returns a shortened version of the description with ellipses at the end' do
-      
+      assert_equal @presentation.description_short(30), 'description description...'
+    end
+
+    it 'raises an error if argument is not an integer' do
+      assert_raises(ArgumentError) { @presentation.description_short('a') }
+    end
+
+    it 'raises an error if argument is less than 1' do
+      assert_raises(ArgumentError) { @presentation.description_short(-1) }
     end
 
   end

--- a/test/models/presentation_test.rb
+++ b/test/models/presentation_test.rb
@@ -30,8 +30,16 @@ describe Presentation do
   it 'rejects a presentation without a location' do
     @presentation.location = nil
     result = @presentation.valid?
-    
+
     refute result, "Accepted presentation with invalid location"
+  end
+
+  describe '#description_short' do
+
+    it 'returns a shortened version of the description with ellipses at the end' do
+      
+    end
+
   end
 
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -7,21 +7,43 @@ describe User do
     @user = build(:user)
   end
 
-  it 'requires a user to be valid' do
+  it "requires a user to be valid" do
     result = @user.valid?
     assert result, "Valid user was considered invalid"
   end
 
-  it 'rejects a user without a first name' do
+  it "rejects a user without a first name" do
     @user.first_name = nil
     result = @user.valid?
     refute result, "Accepted user with invalid first name"
   end
 
-  it 'rejects a user without a last name' do
+  it "rejects a user without a last name" do
     @user.last_name = nil
     result = @user.valid?
     refute result, "Accepted user with invalid last name"
+  end
+
+  describe "#presentations_as_presenter" do
+
+    let(:pres) { create(:presentation) }
+
+    it "gets all a user's presentations where they are the presenter" do
+      create(:participation, user: @user, presentation: pres, is_presenter: true)
+      assert_equal @user.presentations_as_presenter, [pres], "Presenter cannot see their presentations"
+    end
+
+    it "does not include any presentations where the user is not the presenter" do
+      pres_2 = create(:presentation)
+      create(:participation, user: @user, presentation: pres, is_presenter: true)
+      create(:participation, user: @user, presentation: pres_2, is_presenter: false)
+      assert_equal @user.presentations_as_presenter, [pres], "Presenter sees more than their presentations"
+    end
+
+    it "returns an empty ActiveRecord relation if the user is never a presenter" do
+      assert_equal @user.presentations_as_presenter, []
+    end
+
   end
 
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -56,6 +56,10 @@ describe User do
       assert_equal @user.presentations_as(:guest), []
     end
 
+    it "returns an empty relation if nil is passed in" do
+      assert_equal @user.presentations_as(nil), []
+    end
+
   end
 
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -27,46 +27,4 @@ describe User do
     refute result, "Accepted user with invalid last name"
   end
 
-  # describe "#presentations_as" do
-  #
-  #   let(:pres) { create(:presentation) }
-  #
-  #   it "gets all of a user's presentations where they are the presenter" do
-  #     create(:participation, user: @user, presentation: pres, is_presenter: true)
-  #
-  #     assert_equal @user.presentations_as(:presenter), [pres]
-  #   end
-  #
-  #   it "gets all of user's presentations where they are the attendee" do
-  #     create(:participation, user: @user, presentation: pres, is_presenter: false)
-  #
-  #     assert_equal @user.presentations_as(:attendee), [pres]
-  #   end
-  #
-  #   it "does not include any presentations where the user is not the presenter if :presenter is passed as an argument" do
-  #     pres_2 = create(:presentation)
-  #     create(:participation, user: @user, presentation: pres, is_presenter: true)
-  #     create(:participation, user: @user, presentation: pres_2, is_presenter: false)
-  #
-  #     assert_equal @user.presentations_as(:presenter), [pres]
-  #   end
-  #
-  #   it "does not include any presentations where the user is not an attendee if :attendee is passed as an arguent" do
-  #     pres_2 = create(:presentation)
-  #     create(:participation, user: @user, presentation: pres, is_presenter: true)
-  #     create(:participation, user: @user, presentation: pres_2, is_presenter: false)
-  #
-  #     assert_equal @user.presentations_as(:attendee), [pres_2]
-  #   end
-  #
-  #   it "returns an empty relation if a role other than :presenter and :attendee is passed" do
-  #     assert_equal @user.presentations_as(:guest), []
-  #   end
-  #
-  #   it "returns an empty relation if nil is passed in" do
-  #     assert_equal @user.presentations_as(nil), []
-  #   end
-  #
-  # end
-
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -24,24 +24,36 @@ describe User do
     refute result, "Accepted user with invalid last name"
   end
 
-  describe "#presentations_as_presenter" do
+  describe "#presentations_as" do
 
     let(:pres) { create(:presentation) }
 
-    it "gets all a user's presentations where they are the presenter" do
+    it "gets all of a user's presentations where they are the presenter" do
       create(:participation, user: @user, presentation: pres, is_presenter: true)
-      assert_equal @user.presentations_as_presenter, [pres], "Presenter cannot see their presentations"
+      assert_equal @user.presentations_as(:presenter), [pres]
     end
 
-    it "does not include any presentations where the user is not the presenter" do
+    it "gets all of user's presentations where they are the attendee" do
+      create(:participation, user: @user, presentation: pres, is_presenter: false)
+      assert_equal @user.presentations_as(:attendee), [pres]
+    end
+
+    it "does not include any presentations where the user is not the presenter if :presenter is passed as an argument" do
       pres_2 = create(:presentation)
       create(:participation, user: @user, presentation: pres, is_presenter: true)
       create(:participation, user: @user, presentation: pres_2, is_presenter: false)
-      assert_equal @user.presentations_as_presenter, [pres], "Presenter sees more than their presentations"
+      assert_equal @user.presentations_as(:presenter), [pres]
     end
 
-    it "returns an empty ActiveRecord relation if the user is never a presenter" do
-      assert_equal @user.presentations_as_presenter, []
+    it "does not include any presentations where the user is not an attendee if :attendee is passed as an arguent" do
+      pres_2 = create(:presentation)
+      create(:participation, user: @user, presentation: pres, is_presenter: true)
+      create(:participation, user: @user, presentation: pres_2, is_presenter: false)
+      assert_equal @user.presentations_as(:attendee), [pres_2]
+    end
+
+    it "returns an empty relation if a role other than :presenter and :attendee is passed" do
+      assert_equal @user.presentations_as(:guest), []
     end
 
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -9,18 +9,21 @@ describe User do
 
   it "requires a user to be valid" do
     result = @user.valid?
+
     assert result, "Valid user was considered invalid"
   end
 
   it "rejects a user without a first name" do
     @user.first_name = nil
     result = @user.valid?
+
     refute result, "Accepted user with invalid first name"
   end
 
   it "rejects a user without a last name" do
     @user.last_name = nil
     result = @user.valid?
+
     refute result, "Accepted user with invalid last name"
   end
 
@@ -30,11 +33,13 @@ describe User do
 
     it "gets all of a user's presentations where they are the presenter" do
       create(:participation, user: @user, presentation: pres, is_presenter: true)
+
       assert_equal @user.presentations_as(:presenter), [pres]
     end
 
     it "gets all of user's presentations where they are the attendee" do
       create(:participation, user: @user, presentation: pres, is_presenter: false)
+
       assert_equal @user.presentations_as(:attendee), [pres]
     end
 
@@ -42,6 +47,7 @@ describe User do
       pres_2 = create(:presentation)
       create(:participation, user: @user, presentation: pres, is_presenter: true)
       create(:participation, user: @user, presentation: pres_2, is_presenter: false)
+
       assert_equal @user.presentations_as(:presenter), [pres]
     end
 
@@ -49,6 +55,7 @@ describe User do
       pres_2 = create(:presentation)
       create(:participation, user: @user, presentation: pres, is_presenter: true)
       create(:participation, user: @user, presentation: pres_2, is_presenter: false)
+      
       assert_equal @user.presentations_as(:attendee), [pres_2]
     end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -27,46 +27,46 @@ describe User do
     refute result, "Accepted user with invalid last name"
   end
 
-  describe "#presentations_as" do
-
-    let(:pres) { create(:presentation) }
-
-    it "gets all of a user's presentations where they are the presenter" do
-      create(:participation, user: @user, presentation: pres, is_presenter: true)
-
-      assert_equal @user.presentations_as(:presenter), [pres]
-    end
-
-    it "gets all of user's presentations where they are the attendee" do
-      create(:participation, user: @user, presentation: pres, is_presenter: false)
-
-      assert_equal @user.presentations_as(:attendee), [pres]
-    end
-
-    it "does not include any presentations where the user is not the presenter if :presenter is passed as an argument" do
-      pres_2 = create(:presentation)
-      create(:participation, user: @user, presentation: pres, is_presenter: true)
-      create(:participation, user: @user, presentation: pres_2, is_presenter: false)
-
-      assert_equal @user.presentations_as(:presenter), [pres]
-    end
-
-    it "does not include any presentations where the user is not an attendee if :attendee is passed as an arguent" do
-      pres_2 = create(:presentation)
-      create(:participation, user: @user, presentation: pres, is_presenter: true)
-      create(:participation, user: @user, presentation: pres_2, is_presenter: false)
-      
-      assert_equal @user.presentations_as(:attendee), [pres_2]
-    end
-
-    it "returns an empty relation if a role other than :presenter and :attendee is passed" do
-      assert_equal @user.presentations_as(:guest), []
-    end
-
-    it "returns an empty relation if nil is passed in" do
-      assert_equal @user.presentations_as(nil), []
-    end
-
-  end
+  # describe "#presentations_as" do
+  #
+  #   let(:pres) { create(:presentation) }
+  #
+  #   it "gets all of a user's presentations where they are the presenter" do
+  #     create(:participation, user: @user, presentation: pres, is_presenter: true)
+  #
+  #     assert_equal @user.presentations_as(:presenter), [pres]
+  #   end
+  #
+  #   it "gets all of user's presentations where they are the attendee" do
+  #     create(:participation, user: @user, presentation: pres, is_presenter: false)
+  #
+  #     assert_equal @user.presentations_as(:attendee), [pres]
+  #   end
+  #
+  #   it "does not include any presentations where the user is not the presenter if :presenter is passed as an argument" do
+  #     pres_2 = create(:presentation)
+  #     create(:participation, user: @user, presentation: pres, is_presenter: true)
+  #     create(:participation, user: @user, presentation: pres_2, is_presenter: false)
+  #
+  #     assert_equal @user.presentations_as(:presenter), [pres]
+  #   end
+  #
+  #   it "does not include any presentations where the user is not an attendee if :attendee is passed as an arguent" do
+  #     pres_2 = create(:presentation)
+  #     create(:participation, user: @user, presentation: pres, is_presenter: true)
+  #     create(:participation, user: @user, presentation: pres_2, is_presenter: false)
+  #
+  #     assert_equal @user.presentations_as(:attendee), [pres_2]
+  #   end
+  #
+  #   it "returns an empty relation if a role other than :presenter and :attendee is passed" do
+  #     assert_equal @user.presentations_as(:guest), []
+  #   end
+  #
+  #   it "returns an empty relation if nil is passed in" do
+  #     assert_equal @user.presentations_as(nil), []
+  #   end
+  #
+  # end
 
 end


### PR DESCRIPTION
I added code that modifies the presentation index. For a general user, the presentations are separated based on whether the logged-in user is a presenter or just attending. An admin still sees a big list of the presentations, however. 

Note that I extracted out the presentation table into a partial to keep things DRY. 

This PR includes unit & acceptance tests. 

I also a few minor fixes along the way (missing column headers, seeds file fix, minor spacing stuff, etc). 