### PR TITLE
Admin view feedback

### DIFF
--- a/test/features/responses/view_feedback_test.rb
+++ b/test/features/responses/view_feedback_test.rb
@@ -22,25 +22,25 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
            user_id: @presenter2.id,
            presentation_id: @presentation.id)
     @survey1 = create(:survey,
-                       presentation_id: @presentation.id,
-                       presenter_id: @presenter1.id,
-                       subject: "#{@presenter1.first_name} #{@presenter1.last_name}")
-     create_list(:question, 2, :number, :required, survey_id: @survey1.id) do |question|
-       create(:response, :number, question_id: question.id, user_id: @user.id)
-     end
-     create_list(:question, 2, :text, :required, survey_id: @survey1.id) do |question|
-       create(:response, :text, question_id: question.id, user_id: @user.id)
-     end
-     @survey2 = create(:survey,
-                       presentation_id: @presentation.id,
-                       presenter_id: @presenter2.id,
-                       subject: "#{@presenter2.first_name} #{@presenter2.last_name}")
-     create_list(:question, 2, :number, :required, survey_id: @survey2.id) do |question|
-       create(:response, :number, question_id: question.id, user_id: @user.id)
-     end
-     create_list(:question, 2, :text, :required, survey_id: @survey2.id) do |question|
-       create(:response, :text, question_id: question.id, user_id: @user.id)
-     end
+                      presentation_id: @presentation.id,
+                      presenter_id: @presenter1.id,
+                      subject: "#{@presenter1.first_name} #{@presenter1.last_name}")
+    create_list(:question, 2, :number, :required, survey_id: @survey1.id) do |question|
+      create(:response, :number, question_id: question.id, user_id: @user.id)
+    end
+    create_list(:question, 2, :text, :required, survey_id: @survey1.id) do |question|
+      create(:response, :text, question_id: question.id, user_id: @user.id)
+    end
+    @survey2 = create(:survey,
+                      presentation_id: @presentation.id,
+                      presenter_id: @presenter2.id,
+                      subject: "#{@presenter2.first_name} #{@presenter2.last_name}")
+    create_list(:question, 2, :number, :required, survey_id: @survey2.id) do |question|
+      create(:response, :number, question_id: question.id, user_id: @user.id)
+    end
+    create_list(:question, 2, :text, :required, survey_id: @survey2.id) do |question|
+      create(:response, :text, question_id: question.id, user_id: @user.id)
+    end
   end
 
   after do

--- a/test/features/responses/view_feedback_test.rb
+++ b/test/features/responses/view_feedback_test.rb
@@ -67,7 +67,7 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
   end
 
   feature 'viewing feedback as admin' do
-    scenario 'admin user can see feedback for all presenters' do
+    before do
       @admin = create(:user, :admin)
       @presentation_with_presenters = create(:presentation)
       @presenter1 = create(:user,
@@ -105,6 +105,9 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
         create(:response, :text, question_id: question.id, user_id: @user.id)
       end
 
+    end
+    
+    scenario 'admin user can see feedback for all presenters' do
       login_as(@admin, scope: :user)
 
       visit presentation_responses_path(@presentation_with_presenters)

--- a/test/features/responses/view_feedback_test.rb
+++ b/test/features/responses/view_feedback_test.rb
@@ -71,19 +71,17 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
       @admin = create(:user, :admin)
       @presentation_with_presenters = create(:presentation)
       @presenter1 = create(:user,
-                          first_name: 'Burton',
-                          last_name: 'White')
+                           first_name: 'Burton',
+                           last_name: 'White')
       @presenter2 = create(:user,
-                          first_name: 'Steve',
-                          last_name: 'Cooper')
+                           first_name: 'Steve',
+                           last_name: 'Cooper')
       create(:participation, :presenter,
              user_id: @presenter1.id,
-             presentation_id: @presentation_with_presenters.id
-             )
+             presentation_id: @presentation_with_presenters.id)
       create(:participation, :presenter,
-            user_id: @presenter2.id,
-            presentation_id: @presentation_with_presenters.id
-            )
+             user_id: @presenter2.id,
+             presentation_id: @presentation_with_presenters.id)
       @survey1 = create(:survey,
                         presentation_id: @presentation_with_presenters.id,
                         presenter_id: @presenter1.id,
@@ -104,15 +102,14 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
       create_list(:question, 2, :text, :required, survey_id: @survey2.id) do |question|
         create(:response, :text, question_id: question.id, user_id: @user.id)
       end
-
     end
-    
+
     scenario 'admin user can see feedback for all presenters' do
       login_as(@admin, scope: :user)
 
       visit presentation_responses_path(@presentation_with_presenters)
 
-      assert page.has_content?("#{@presenter1.first_name} #{@presenter1.last_name}") && page.has_content?("#{@presenter2.first_name} #{@presenter2.last_name}"), "Admin unable to see both presenters."
+      assert page.has_content?("#{@presenter1.first_name} #{@presenter1.last_name}") && page.has_content?("#{@presenter2.first_name} #{@presenter2.last_name}"), 'Admin unable to see both presenters.'
     end
   end
 end

--- a/test/features/responses/view_feedback_test.rb
+++ b/test/features/responses/view_feedback_test.rb
@@ -6,30 +6,53 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
   Warden.test_mode!
 
   before do
+    @admin = create(:user, :admin)
     @user = create(:user)
+    @presenter1 = create(:user,
+                         first_name: 'Burton',
+                         last_name: 'White')
+    @presenter2 = create(:user,
+                         first_name: 'Steve',
+                         last_name: 'Cooper')
     @presentation = create(:presentation)
-    create(:participation,
-           user_id: @user.id,
+    create(:participation, :presenter,
+           user_id: @presenter1.id,
            presentation_id: @presentation.id)
-
-    @survey = create(:survey, presentation_id: @presentation.id)
-    create_list(:question, 5, :number, :required, survey_id: @survey.id) do |question|
-      create(:response, :number, question_id: question.id, user_id: @user.id)
-    end
-    create_list(:question, 5, :text, :required, survey_id: @survey.id) do |question|
-      create(:response, :text, question_id: question.id, user_id: @user.id)
-    end
-
-    login_as(@user, scope: :user)
-
-    visit presentation_responses_path(@presentation)
+    create(:participation, :presenter,
+           user_id: @presenter2.id,
+           presentation_id: @presentation.id)
+    @survey1 = create(:survey,
+                       presentation_id: @presentation.id,
+                       presenter_id: @presenter1.id,
+                       subject: "#{@presenter1.first_name} #{@presenter1.last_name}")
+     create_list(:question, 2, :number, :required, survey_id: @survey1.id) do |question|
+       create(:response, :number, question_id: question.id, user_id: @user.id)
+     end
+     create_list(:question, 2, :text, :required, survey_id: @survey1.id) do |question|
+       create(:response, :text, question_id: question.id, user_id: @user.id)
+     end
+     @survey2 = create(:survey,
+                       presentation_id: @presentation.id,
+                       presenter_id: @presenter2.id,
+                       subject: "#{@presenter2.first_name} #{@presenter2.last_name}")
+     create_list(:question, 2, :number, :required, survey_id: @survey2.id) do |question|
+       create(:response, :number, question_id: question.id, user_id: @user.id)
+     end
+     create_list(:question, 2, :text, :required, survey_id: @survey2.id) do |question|
+       create(:response, :text, question_id: question.id, user_id: @user.id)
+     end
   end
 
   after do
     Warden.test_reset!
   end
 
-  feature 'viewing feedback' do
+  feature 'viewing feedback as presenter' do
+    before do
+      login_as(@presenter1, scope: :user)
+
+      visit presentation_responses_path(@presentation)
+    end
     scenario 'feedback for scale (number) responses render properly as chart' do
       number_question_ids = Question.where(response_type: 'number').pluck(:id)
 
@@ -68,48 +91,14 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
 
   feature 'viewing feedback as admin' do
     before do
-      @admin = create(:user, :admin)
-      @presentation_with_presenters = create(:presentation)
-      @presenter1 = create(:user,
-                           first_name: 'Burton',
-                           last_name: 'White')
-      @presenter2 = create(:user,
-                           first_name: 'Steve',
-                           last_name: 'Cooper')
-      create(:participation, :presenter,
-             user_id: @presenter1.id,
-             presentation_id: @presentation_with_presenters.id)
-      create(:participation, :presenter,
-             user_id: @presenter2.id,
-             presentation_id: @presentation_with_presenters.id)
-      @survey1 = create(:survey,
-                        presentation_id: @presentation_with_presenters.id,
-                        presenter_id: @presenter1.id,
-                        subject: "#{@presenter1.first_name} #{@presenter1.last_name}")
-      create_list(:question, 2, :number, :required, survey_id: @survey1.id) do |question|
-        create(:response, :number, question_id: question.id, user_id: @user.id)
-      end
-      create_list(:question, 2, :text, :required, survey_id: @survey1.id) do |question|
-        create(:response, :text, question_id: question.id, user_id: @user.id)
-      end
-      @survey2 = create(:survey,
-                        presentation_id: @presentation_with_presenters.id,
-                        presenter_id: @presenter2.id,
-                        subject: "#{@presenter2.first_name} #{@presenter2.last_name}")
-      create_list(:question, 2, :number, :required, survey_id: @survey2.id) do |question|
-        create(:response, :number, question_id: question.id, user_id: @user.id)
-      end
-      create_list(:question, 2, :text, :required, survey_id: @survey2.id) do |question|
-        create(:response, :text, question_id: question.id, user_id: @user.id)
-      end
+      login_as(@admin, scope: :user)
+
+      visit presentation_responses_path(@presentation)
     end
 
     scenario 'admin user can see feedback for all presenters' do
-      login_as(@admin, scope: :user)
-
-      visit presentation_responses_path(@presentation_with_presenters)
-
-      assert page.has_content?("#{@presenter1.first_name} #{@presenter1.last_name}") && page.has_content?("#{@presenter2.first_name} #{@presenter2.last_name}"), 'Admin unable to see both presenters.'
+      assert page.has_content?("#{@presenter1.first_name} #{@presenter1.last_name}"), 'Admin unable to see first presenter'
+      assert page.has_content?("#{@presenter2.first_name} #{@presenter2.last_name}"), 'Admin unable to see second presenter.'
     end
   end
 end

--- a/test/features/responses/view_feedback_test.rb
+++ b/test/features/responses/view_feedback_test.rb
@@ -64,9 +64,52 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
                'Average was not rendered properly'
       end
     end
+  end
 
-    scenario 'admin user can see all feedback including responses for presenters' do
-      
+  feature 'viewing feedback as admin' do
+    scenario 'admin user can see feedback for all presenters' do
+      @admin = create(:user, :admin)
+      @presentation_with_presenters = create(:presentation)
+      @presenter1 = create(:user,
+                          first_name: 'Burton',
+                          last_name: 'White')
+      @presenter2 = create(:user,
+                          first_name: 'Steve',
+                          last_name: 'Cooper')
+      create(:participation, :presenter,
+             user_id: @presenter1.id,
+             presentation_id: @presentation_with_presenters.id
+             )
+      create(:participation, :presenter,
+            user_id: @presenter2.id,
+            presentation_id: @presentation_with_presenters.id
+            )
+      @survey1 = create(:survey,
+                        presentation_id: @presentation_with_presenters.id,
+                        presenter_id: @presenter1.id,
+                        subject: "#{@presenter1.first_name} #{@presenter1.last_name}")
+      create_list(:question, 2, :number, :required, survey_id: @survey1.id) do |question|
+        create(:response, :number, question_id: question.id, user_id: @user.id)
+      end
+      create_list(:question, 2, :text, :required, survey_id: @survey1.id) do |question|
+        create(:response, :text, question_id: question.id, user_id: @user.id)
+      end
+      @survey2 = create(:survey,
+                        presentation_id: @presentation_with_presenters.id,
+                        presenter_id: @presenter2.id,
+                        subject: "#{@presenter2.first_name} #{@presenter2.last_name}")
+      create_list(:question, 2, :number, :required, survey_id: @survey2.id) do |question|
+        create(:response, :number, question_id: question.id, user_id: @user.id)
+      end
+      create_list(:question, 2, :text, :required, survey_id: @survey2.id) do |question|
+        create(:response, :text, question_id: question.id, user_id: @user.id)
+      end
+
+      login_as(@admin, scope: :user)
+
+      visit presentation_responses_path(@presentation_with_presenters)
+
+      assert page.has_content?("#{@presenter1.first_name} #{@presenter1.last_name}") && page.has_content?("#{@presenter2.first_name} #{@presenter2.last_name}"), "Admin unable to see both presenters."
     end
   end
 end

--- a/test/features/responses/view_feedback_test.rb
+++ b/test/features/responses/view_feedback_test.rb
@@ -64,5 +64,9 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
                'Average was not rendered properly'
       end
     end
+
+    scenario 'admin user can see all feedback including responses for presenters' do
+      
+    end
   end
 end

--- a/test/helpers/presentations_helper_test.rb
+++ b/test/helpers/presentations_helper_test.rb
@@ -68,7 +68,17 @@ class PresentationsHelperTest < ActionView::TestCase
   end
 
   describe '#feedback_header' do
-    it 'tests pending...'
+    it 'returns "Admin" for header of feedback (right-most) column when user is Admin' do
+      text = feedback_header(@admin)
+
+      assert_equal text, 'Admin', 'Returns something other than "Admin"'
+    end
+
+    it 'returns "Feedback" for header of feedback (right-most) column when user is General User' do
+      text = feedback_header(@user)
+
+      assert_equal text, 'Feedback', 'Returns something other than "Feedback"'
+    end
   end
 
   describe '#display_description' do
@@ -155,7 +165,24 @@ class PresentationsHelperTest < ActionView::TestCase
   end
 
   describe '#survey_link_for' do
-    it 'tests pending...'
+    it 'renders link to see surveys if presentation already has surveys created' do
+      presentation = create(:presentation)
+      create(:survey, presentation_id: presentation.id)
+
+      link_text = survey_link_for(presentation)
+
+      assert link_text.include?('See Surveys'), 'Link does not contain "See Surveys"'
+      refute link_text.include?('Create Survey'), 'Link contains "Create Survey"'
+    end
+
+    it 'renders link to create surveys if presentation has no surveys' do
+      presentation = create(:presentation)
+
+      link_text = survey_link_for(presentation)
+
+      assert link_text.include?('Create Survey'), 'Link does not contain "Create Survey"'
+      refute link_text.include?('See Surveys'), 'Link contains "See Survyes "'
+    end
   end
 
   describe '#presentation_admin_options' do


### PR DESCRIPTION
Test to make sure admin can see feedback on all the presenters.

Refactored variable declarations and before blocks. Hopefully will make it easier when we begin adding functionality where presenter can only see responses on their surveys

