### PR TITLE
Presenter feedback

### DIFF
--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -108,6 +108,9 @@ class ResponsesController < ApplicationController
     question_data
   end
 
+  #
+  # Define and format data for number (scale) questions
+  #
   def get_question_data(question)
     return unless question.response_type == 'number'
     question_data = format_question_data(question)

--- a/app/helpers/responses_helper.rb
+++ b/app/helpers/responses_helper.rb
@@ -60,4 +60,13 @@ module ResponsesHelper
     return if response.value.empty?
     content_tag(:li, response.value, class: 'list-group-item')
   end
+
+  #
+  # Filter based on user permissions (admin, presenter)
+  # Presenters can only see overall data and their own surveys
+  # Admins can see all
+  #
+  def can_see_survey_results(survey)
+    survey.presenter_id.nil? || current_user.is_admin || survey.presenter_id == current_user.id
+  end
 end

--- a/app/helpers/responses_helper.rb
+++ b/app/helpers/responses_helper.rb
@@ -66,7 +66,7 @@ module ResponsesHelper
   # Presenters can only see overall data and their own surveys
   # Admins can see all
   #
-  def can_see_survey_results(survey)
-    survey.presenter_id.nil? || current_user.is_admin || survey.presenter_id == current_user.id
+  def can_see_survey_results(survey, user)
+    survey.presenter_id.nil? || user.is_admin || survey.presenter_id == user.id
   end
 end

--- a/app/views/responses/index.html.erb
+++ b/app/views/responses/index.html.erb
@@ -16,7 +16,9 @@
   <!-- /.row -->
 
   <% @presentation.surveys.each do |survey| %>
-    <%= render 'results', survey: survey %>
+    <% if can_see_survey_results(survey) %>
+      <%= render 'results', survey: survey %>
+    <% end %>
   <% end %>
 
 </div>

--- a/app/views/responses/index.html.erb
+++ b/app/views/responses/index.html.erb
@@ -16,7 +16,7 @@
   <!-- /.row -->
 
   <% @presentation.surveys.each do |survey| %>
-    <% if can_see_survey_results(survey) %>
+    <% if can_see_survey_results(survey, current_user) %>
       <%= render 'results', survey: survey %>
     <% end %>
   <% end %>

--- a/test/features/responses/view_feedback_test.rb
+++ b/test/features/responses/view_feedback_test.rb
@@ -68,7 +68,7 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
     scenario 'presenter can see feedback for surveys about themselves' do
       presenter_survey = create(:survey, presentation_id: @presentation.id, presenter_id: @user.id)
       create_list(:question, 1, :text, :required, survey_id: presenter_survey.id) do |question|
-        create(:response, value: 'Response for presenter only', question_id: question.id, user_id: @user.id, )
+        create(:response, value: 'Response for presenter only', question_id: question.id, user_id: @user.id)
       end
       visit presentation_responses_path(@presentation)
       assert page.has_content?('Response for presenter only')
@@ -78,7 +78,7 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
       another_user = create(:user)
       presenter_survey = create(:survey, presentation_id: @presentation.id, presenter_id: another_user.id)
       create_list(:question, 1, :text, :required, survey_id: presenter_survey.id) do |question|
-        create(:response, value: 'Response for presenter only', question_id: question.id, user_id: @user.id, )
+        create(:response, value: 'Response for presenter only', question_id: question.id, user_id: @user.id)
       end
       visit presentation_responses_path(@presentation)
       refute page.has_content?('Response for presenter only')
@@ -89,7 +89,7 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
       another_user = create(:user)
       presenter_survey = create(:survey, presentation_id: @presentation.id, presenter_id: another_user.id)
       create_list(:question, 1, :text, :required, survey_id: presenter_survey.id) do |question|
-        create(:response, value: 'Response for presenter only', question_id: question.id, user_id: @user.id, )
+        create(:response, value: 'Response for presenter only', question_id: question.id, user_id: @user.id)
       end
       login_as(admin)
       visit presentation_responses_path(@presentation)

--- a/test/features/responses/view_feedback_test.rb
+++ b/test/features/responses/view_feedback_test.rb
@@ -8,14 +8,17 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
   before do
     @user = create(:user)
     @presentation = create(:presentation)
+    
     create(:participation,
            user_id: @user.id,
            presentation_id: @presentation.id)
 
     @survey = create(:survey, presentation_id: @presentation.id)
+    
     create_list(:question, 5, :number, :required, survey_id: @survey.id) do |question|
       create(:response, :number, question_id: question.id, user_id: @user.id)
     end
+    
     create_list(:question, 5, :text, :required, survey_id: @survey.id) do |question|
       create(:response, :text, question_id: question.id, user_id: @user.id)
     end
@@ -67,20 +70,26 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
 
     scenario 'presenter can see feedback for surveys about themselves' do
       presenter_survey = create(:survey, presentation_id: @presentation.id, presenter_id: @user.id)
+      
       create_list(:question, 1, :text, :required, survey_id: presenter_survey.id) do |question|
         create(:response, value: 'Response for presenter only', question_id: question.id, user_id: @user.id)
       end
+      
       visit presentation_responses_path(@presentation)
+
       assert page.has_content?('Response for presenter only')
     end
 
     scenario 'presenter cannot see feedback for surveys about another presenter' do
       another_user = create(:user)
       presenter_survey = create(:survey, presentation_id: @presentation.id, presenter_id: another_user.id)
+      
       create_list(:question, 1, :text, :required, survey_id: presenter_survey.id) do |question|
         create(:response, value: 'Response for presenter only', question_id: question.id, user_id: @user.id)
       end
+      
       visit presentation_responses_path(@presentation)
+      
       refute page.has_content?('Response for presenter only')
     end
 
@@ -88,11 +97,15 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
       admin = create(:user, :admin)
       another_user = create(:user)
       presenter_survey = create(:survey, presentation_id: @presentation.id, presenter_id: another_user.id)
+      
       create_list(:question, 1, :text, :required, survey_id: presenter_survey.id) do |question|
         create(:response, value: 'Response for presenter only', question_id: question.id, user_id: @user.id)
       end
+      
       login_as(admin)
+      
       visit presentation_responses_path(@presentation)
+      
       assert page.has_content?('Response for presenter only')
     end
   end

--- a/test/features/responses/view_feedback_test.rb
+++ b/test/features/responses/view_feedback_test.rb
@@ -64,5 +64,36 @@ class ViewFeedbackTest < Capybara::Rails::TestCase
                'Average was not rendered properly'
       end
     end
+
+    scenario 'presenter can see feedback for surveys about themselves' do
+      presenter_survey = create(:survey, presentation_id: @presentation.id, presenter_id: @user.id)
+      create_list(:question, 1, :text, :required, survey_id: presenter_survey.id) do |question|
+        create(:response, value: 'Response for presenter only', question_id: question.id, user_id: @user.id, )
+      end
+      visit presentation_responses_path(@presentation)
+      assert page.has_content?('Response for presenter only')
+    end
+
+    scenario 'presenter cannot see feedback for surveys about another presenter' do
+      another_user = create(:user)
+      presenter_survey = create(:survey, presentation_id: @presentation.id, presenter_id: another_user.id)
+      create_list(:question, 1, :text, :required, survey_id: presenter_survey.id) do |question|
+        create(:response, value: 'Response for presenter only', question_id: question.id, user_id: @user.id, )
+      end
+      visit presentation_responses_path(@presentation)
+      refute page.has_content?('Response for presenter only')
+    end
+
+    scenario 'admin can see feedback for all surveys' do
+      admin = create(:user, :admin)
+      another_user = create(:user)
+      presenter_survey = create(:survey, presentation_id: @presentation.id, presenter_id: another_user.id)
+      create_list(:question, 1, :text, :required, survey_id: presenter_survey.id) do |question|
+        create(:response, value: 'Response for presenter only', question_id: question.id, user_id: @user.id, )
+      end
+      login_as(admin)
+      visit presentation_responses_path(@presentation)
+      assert page.has_content?('Response for presenter only')
+    end
   end
 end

--- a/test/helpers/responses_helper_test.rb
+++ b/test/helpers/responses_helper_test.rb
@@ -99,4 +99,22 @@ class ResponsesHelperTest < ActionView::TestCase
       assert_equal number_errors.length, number_list_length, 'Number errors do not match resulting list'
     end
   end
+
+  describe '#can_see_survey_results' do
+    it 'returns true if a survey is not associated to a presenter' do
+      survey = create(:survey)
+      assert can_see_survey_results(survey, @user), 'survey.presenter_id is not nil'
+    end
+
+    it 'returns true if a user\'s id is not equal to the survey\'s presenter_id' do
+      survey = create(:survey, presenter_id: @user.id)
+      assert can_see_survey_results(survey, @user), 'survey.presenter_id does not match user.id'
+    end
+
+    it 'returns true if a user is an admin' do
+      admin = create(:user, :admin)
+      survey = create(:survey, presenter_id: @user.id)
+      assert can_see_survey_results(survey, admin), 'user is not an admin'
+    end
+  end
 end

--- a/test/helpers/responses_helper_test.rb
+++ b/test/helpers/responses_helper_test.rb
@@ -103,17 +103,20 @@ class ResponsesHelperTest < ActionView::TestCase
   describe '#can_see_survey_results' do
     it 'returns true if a survey is not associated to a presenter' do
       survey = create(:survey)
+      
       assert can_see_survey_results(survey, @user), 'survey.presenter_id is not nil'
     end
 
     it 'returns true if a user\'s id is not equal to the survey\'s presenter_id' do
       survey = create(:survey, presenter_id: @user.id)
+      
       assert can_see_survey_results(survey, @user), 'survey.presenter_id does not match user.id'
     end
 
     it 'returns true if a user is an admin' do
       admin = create(:user, :admin)
       survey = create(:survey, presenter_id: @user.id)
+      
       assert can_see_survey_results(survey, admin), 'user is not an admin'
     end
   end


### PR DESCRIPTION
- Presenters can see only feedback about overall surveys and surveys about themselves
- Presenters cannot see feedback for other presenters
- New Unit tests for can_see_survey_results
- Additional Integration tests for results index